### PR TITLE
Feature/services

### DIFF
--- a/server/config/seeds/seed.js
+++ b/server/config/seeds/seed.js
@@ -1,0 +1,15 @@
+const db = require('../connection');
+const { Service } = require('../../models');
+
+const servicesData = require('./serviceData');
+
+db.once('open', async () => {
+  // clean db
+  await Service.deleteMany({});
+
+  // bulk create model
+  await Service.insertMany(servicesData);
+
+  console.log('Seeding complete');
+  process.exit(0);
+});

--- a/server/config/seeds/serviceData.js
+++ b/server/config/seeds/serviceData.js
@@ -1,0 +1,47 @@
+// Master list array. If we want to add more services, here's where to do it.
+// [name, price, tiered, url]
+const servicesArray = [
+  ['Amazon Prime Video', 9, true, 'https://www.amazon.com/'],
+  ['Apple TV+', 5, true, 'https://tv.apple.com/'],
+  ['Criterion', 11, false, 'https://www.criterionchannel.com/'],
+  ['Crunchyroll', 0, true, 'https://www.crunchyroll.com/'],
+  ['Disney+', 8, true, 'https://www.disneyplus.com/'],
+  ['Fubo', 65, true, 'https://www.fubo.tv/'],
+  ['Funimation', 0, true, 'https://www.funimation.com/'],
+  ['HBO max', 15, false, 'https://www.hbomax.com/'],
+  ['Hulu', 7, true, 'https://www.hulu.com/'],
+  ['Netflix', 9, true, 'https://www.netflix.com/'],
+  ['Paramount+', 6, true, 'https://www.paramountplus.com/'],
+  ['Peacock', 0, true, 'https://www.peacocktv.com/'],
+  ['Showtime', 11, false, 'https://www.showtime.com/'],
+  ['Starz', 9, false, 'https://www.starz.com/'],
+  ['YouTube Premium', 12, false, 'https://www.youtube.com/'],
+];
+
+/**
+ * Services master list export.
+ * ```
+ * [
+ *   {
+ *      name: string,
+ *      price: int,
+ *      tiered: boolean,
+ *      url: string
+ *   }
+ * ]
+ * ```
+ */
+let servicesList = [];
+
+servicesArray.forEach((service) => {
+  const serviceObj = {
+    name: service[0],
+    price: service[1],
+    tiered: service[2],
+    url: service[3],
+  };
+
+  servicesList = [...servicesList, serviceObj];
+});
+
+module.exports = servicesList;

--- a/server/models/Service.js
+++ b/server/models/Service.js
@@ -1,0 +1,27 @@
+const { Schema, model } = require('mongoose');
+
+const serviceSchema = new Schema({
+  name: {
+    type: String,
+    required: true,
+    trim: true,
+    unique: true,
+  },
+  price: {
+    type: Number,
+    required: true,
+    unique: false,
+  },
+  tiered: {
+    type: Boolean,
+    required: true,
+  },
+  url: {
+    type: String,
+    required: true,
+  },
+});
+
+const Service = model('Service', serviceSchema);
+
+module.exports = Service;

--- a/server/models/index.js
+++ b/server/models/index.js
@@ -1,3 +1,4 @@
 const User = require('./User');
+const Service = require('./Service');
 
-module.exports = { User };
+module.exports = { User, Service };

--- a/server/package.json
+++ b/server/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "start": "node server.js",
     "watch": "nodemon server.js",
-	  "seed": "node config/seeds.js"
+    "seed": "node config/seeds/seed.js"
   },
   "keywords": [],
   "author": "",

--- a/server/schema/resolvers.js
+++ b/server/schema/resolvers.js
@@ -1,12 +1,17 @@
 const { AuthenticationError } = require('apollo-server-express');
-const { User, Courses, Lesson } = require('../models');
+const { User, Service } = require('../models');
 const { signToken } = require('../utils/auth');
 
 const resolvers = {
   Query: {
-
     users: async () => {
       return User.find().select('-__v -password');
+    },
+
+    user: async (parent, { _id }) => {
+      const user = await User.findOne({ _id: _id });
+
+      return user;
     },
 
     me: async (parent, args, context) => {
@@ -19,15 +24,15 @@ const resolvers = {
       throw new AuthenticationError('Not logged in');
     },
 
-    user: async (parent, args, context) => {
-      if (context.user) {
-        const user = await User.findOne({ _id: context.user });
+    services: async () => {
+      return Service.find();
+    },
 
-        return user;
-      }
+    service: async (parent, { _id }) => {
+      const service = await Service.findOne({ _id: _id });
 
-      throw new AuthenticationError('Not logged in');
-    }
+      return service;
+    },
   },
 
   Mutation: {
@@ -66,7 +71,29 @@ const resolvers = {
 
       return { token, user };
     },
-  }
+
+    createService: async (parent, serviceObj) => {
+      const service = await Service.create(serviceObj);
+
+      return service;
+    },
+
+    deleteService: async (parent, { _id }) => {
+      const service = await Service.findOneAndDelete({ _id });
+
+      return { message: 'Service Deleted', service: service };
+    },
+
+    updateService: async (parent, { _id, ...serviceObj }) => {
+      const service = await Service.findOneAndUpdate(
+        { _id: _id },
+        { ...serviceObj },
+        { new: true }
+      );
+
+      return service;
+    },
+  },
 };
 
 module.exports = resolvers;

--- a/server/schema/typeDefs.js
+++ b/server/schema/typeDefs.js
@@ -1,13 +1,25 @@
 const { gql } = require('apollo-server-express');
 
 const typeDefs = gql`
-
   type User {
     _id: ID
     firstName: String
     lastName: String
     email: String
     password: String
+  }
+
+  type Service {
+    _id: ID
+    name: String
+    price: Int
+    tiered: Boolean
+    url: String
+  }
+
+  type DeleteServicePayload {
+    message: String
+    service: Service
   }
 
   type Auth {
@@ -17,15 +29,44 @@ const typeDefs = gql`
 
   type Query {
     me: User
+    user(_id: ID!): User
     users: [User]
-    user: User
+    service(_id: ID!): Service
+    services: [Service]
   }
 
   type Mutation {
-    createUser(firstName: String!, lastName: String!, email: String!, password: String!): Auth
-    updateUser(firstName: String, email: String, lastName: String, password: String): Auth
+    # User mutations
+    createUser(
+      firstName: String!
+      lastName: String!
+      email: String!
+      password: String!
+    ): Auth
+    updateUser(
+      firstName: String
+      email: String
+      lastName: String
+      password: String
+    ): Auth
     login(email: String!, password: String!): Auth
     changePassword(password: String): User
+
+    # Service mutations
+    createService(
+      name: String!
+      price: Int!
+      tiered: Boolean!
+      url: String!
+    ): Service
+    deleteService(_id: ID!): DeleteServicePayload
+    updateService(
+      _id: ID!
+      name: String
+      price: Int
+      tiered: Boolean
+      url: String
+    ): Service
   }
 `;
 


### PR DESCRIPTION
- Adds the Service model and the files necessary for seeding. In the `server` directory, run `npm run seed`
- Adds type defs and resolvers for Services
- Fixes `user` resolver to use `_id` as a parameter rather than `context.user`. (otherwise, it would be identical to the `me` query)

### Note
I'm not certain we will have a need for any of the Service mutations, but I've included them at the very least to be able to say they are there and ready for 'future development' when we would add an admin page.